### PR TITLE
Examples for Eddystone URL and UID beacons

### DIFF
--- a/source/examples/bluetooth-eddystone-uid/config.json
+++ b/source/examples/bluetooth-eddystone-uid/config.json
@@ -1,0 +1,19 @@
+{
+    "microbit-dal": {
+        "bluetooth": {
+            "enabled": 1,
+            "pairing_mode": 0,
+            "private_addressing": 0,
+            "open": 0,
+            "whitelist": 0,
+            "advertising_timeout": 0,
+            "tx_power": 0,
+            "dfu_service": 0,
+            "event_service": 0,
+            "device_info_service": 0,
+            "eddystone_url": 0,
+            "eddystone_uid": 1
+        },
+        "gatt_table_size": "0x600"
+    }
+}

--- a/source/examples/bluetooth-eddystone-uid/main.cpp
+++ b/source/examples/bluetooth-eddystone-uid/main.cpp
@@ -43,8 +43,8 @@ int main()
     // Initialise the micro:bit runtime.
     uBit.init();
 
-    uBit.messageBus.listen(MICROBIT_ID_BUTTON_A, MICROBIT_EVT_ANY, onButtonA);
-    uBit.messageBus.listen(MICROBIT_ID_BUTTON_B, MICROBIT_EVT_ANY, onButtonB);
+    uBit.messageBus.listen(MICROBIT_ID_BUTTON_A, MICROBIT_BUTTON_EVT_CLICK, onButtonA);
+    uBit.messageBus.listen(MICROBIT_ID_BUTTON_B, MICROBIT_BUTTON_EVT_CLICK, onButtonB);
     
     startAdvertising();
     

--- a/source/examples/bluetooth-eddystone-uid/main.cpp
+++ b/source/examples/bluetooth-eddystone-uid/main.cpp
@@ -1,0 +1,52 @@
+#include "MicroBit.h"
+
+MicroBit uBit;
+
+char UID_NAMESPACE[] = {0x0E,0x67,0x47,0x04,0x42,0xD0,0x14,0x06,0xD5,0x83}; // sha-1 hash of "com.bittysoftware" 
+char UID_INSTANCE[]  = {0x00 , 0x00, 0x00, 0x00, 0x00, 0x01};
+const int8_t CALIBRATED_POWERS[] = {-49, -37, -33, -28, -25, -20, -15, -10};
+
+uint8_t advertising = 0;
+uint8_t tx_power_level = 6;
+
+void startAdvertising() {
+    uBit.bleManager.advertiseEddystoneUid(UID_NAMESPACE, UID_INSTANCE, CALIBRATED_POWERS[tx_power_level-1], false);
+    uBit.bleManager.setTransmitPower(6);
+    uBit.display.scroll("ADV");
+    advertising = 1;
+}
+
+void stopAdvertising() {
+    uBit.bleManager.stopAdvertising();
+    uBit.display.scroll("OFF");
+    advertising = 0;
+}
+
+void onButtonA(MicroBitEvent)
+{
+    if (advertising == 1) {
+        return;
+    }
+    startAdvertising();
+}
+
+void onButtonB(MicroBitEvent)
+{
+    if (advertising == 0) {
+        return;
+    }
+    stopAdvertising();
+}
+
+int main()
+{
+    // Initialise the micro:bit runtime.
+    uBit.init();
+
+    uBit.messageBus.listen(MICROBIT_ID_BUTTON_A, MICROBIT_EVT_ANY, onButtonA);
+    uBit.messageBus.listen(MICROBIT_ID_BUTTON_B, MICROBIT_EVT_ANY, onButtonB);
+    
+    startAdvertising();
+    
+    release_fiber();
+}

--- a/source/examples/bluetooth-eddystone-url/config.json
+++ b/source/examples/bluetooth-eddystone-url/config.json
@@ -1,0 +1,19 @@
+{
+    "microbit-dal": {
+        "bluetooth": {
+            "enabled": 1,
+            "pairing_mode": 0,
+            "private_addressing": 0,
+            "open": 0,
+            "whitelist": 0,
+            "advertising_timeout": 0,
+            "tx_power": 0,
+            "dfu_service": 0,
+            "event_service": 0,
+            "device_info_service": 0,
+            "eddystone_url": 1,
+            "eddystone_uid": 0
+        },
+        "gatt_table_size": "0x600"
+    }
+}

--- a/source/examples/bluetooth-eddystone-url/main.cpp
+++ b/source/examples/bluetooth-eddystone-url/main.cpp
@@ -42,8 +42,8 @@ int main()
     // Initialise the micro:bit runtime.
     uBit.init();
 
-    uBit.messageBus.listen(MICROBIT_ID_BUTTON_A, MICROBIT_EVT_ANY, onButtonA);
-    uBit.messageBus.listen(MICROBIT_ID_BUTTON_B, MICROBIT_EVT_ANY, onButtonB);
+    uBit.messageBus.listen(MICROBIT_ID_BUTTON_A, MICROBIT_BUTTON_EVT_CLICK, onButtonA);
+    uBit.messageBus.listen(MICROBIT_ID_BUTTON_B, MICROBIT_BUTTON_EVT_CLICK, onButtonB);
     
     startAdvertising();
     

--- a/source/examples/bluetooth-eddystone-url/main.cpp
+++ b/source/examples/bluetooth-eddystone-url/main.cpp
@@ -1,0 +1,51 @@
+#include "MicroBit.h"
+
+MicroBit uBit;
+
+char URL[] = "https://goo.gl/TlUTF7";
+const int8_t CALIBRATED_POWERS[] = {-49, -37, -33, -28, -25, -20, -15, -10};
+
+uint8_t advertising = 0;
+uint8_t tx_power_level = 6;
+
+void startAdvertising() {
+    uBit.bleManager.advertiseEddystoneUrl(URL, CALIBRATED_POWERS[tx_power_level-1], false);
+    uBit.bleManager.setTransmitPower(tx_power_level);
+    uBit.display.scroll("ADV");
+    advertising = 1;
+}
+
+void stopAdvertising() {
+    uBit.bleManager.stopAdvertising();
+    uBit.display.scroll("OFF");
+    advertising = 0;
+}
+
+void onButtonA(MicroBitEvent)
+{
+    if (advertising == 1) {
+        return;
+    }
+    startAdvertising();
+}
+
+void onButtonB(MicroBitEvent)
+{
+    if (advertising == 0) {
+        return;
+    }
+    stopAdvertising();
+}
+
+int main()
+{
+    // Initialise the micro:bit runtime.
+    uBit.init();
+
+    uBit.messageBus.listen(MICROBIT_ID_BUTTON_A, MICROBIT_EVT_ANY, onButtonA);
+    uBit.messageBus.listen(MICROBIT_ID_BUTTON_B, MICROBIT_EVT_ANY, onButtonB);
+    
+    startAdvertising();
+    
+    release_fiber();
+}


### PR DESCRIPTION
A couple of simple examples for using micro:bit as an Eddystone beacon using with URL frames or UID frames.
