### PR TITLE
Set the target to be fetched from GitHub instead of the (deprecated) Yotta registry

### DIFF
--- a/.yotta.json
+++ b/.yotta.json
@@ -1,5 +1,5 @@
 {
   "build": {
-    "target": "bbc-microbit-classic-gcc,*"
+    "target": "bbc-microbit-classic-gcc,https://github.com/lancaster-university/yotta-target-bbc-microbit-classic-gcc"
   }
 }


### PR DESCRIPTION
The Yotta registry is no longer online, so trying to build from a clean clone throws an error:
```
info: get versions for bbc-microbit-classic-gcc
info: download bbc-microbit-classic-gcc@0.2.3 from the public module registry
error: 'ConnectionError' object has no attribute 'message'
```