### PR TITLE
fixed typo in comments

### DIFF
--- a/source/examples/accelerometer/main.cpp
+++ b/source/examples/accelerometer/main.cpp
@@ -49,7 +49,7 @@ int pixel_from_g(int value)
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     //

--- a/source/examples/bluetooth-eddystone-uid/main.cpp
+++ b/source/examples/bluetooth-eddystone-uid/main.cpp
@@ -40,7 +40,7 @@ void onButtonB(MicroBitEvent)
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     uBit.messageBus.listen(MICROBIT_ID_BUTTON_A, MICROBIT_BUTTON_EVT_CLICK, onButtonA);

--- a/source/examples/bluetooth-eddystone-url/main.cpp
+++ b/source/examples/bluetooth-eddystone-url/main.cpp
@@ -39,7 +39,7 @@ void onButtonB(MicroBitEvent)
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     uBit.messageBus.listen(MICROBIT_ID_BUTTON_A, MICROBIT_BUTTON_EVT_CLICK, onButtonA);

--- a/source/examples/bluetooth-services/main.cpp
+++ b/source/examples/bluetooth-services/main.cpp
@@ -40,7 +40,7 @@ void onDisconnected(MicroBitEvent)
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     // Configuration Tips

--- a/source/examples/bluetooth-uart/main.cpp
+++ b/source/examples/bluetooth-uart/main.cpp
@@ -86,7 +86,7 @@ void onButtonAB(MicroBitEvent)
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     uBit.messageBus.listen(MICROBIT_ID_BLE, MICROBIT_BLE_EVT_CONNECTED, onConnected);

--- a/source/examples/button-events/main.cpp
+++ b/source/examples/button-events/main.cpp
@@ -75,7 +75,7 @@ void onButton(MicroBitEvent e)
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     // Register to receive events when any buttons are clicked, including the A+B virtual button (both buttons at once).

--- a/source/examples/greyscale/main.cpp
+++ b/source/examples/greyscale/main.cpp
@@ -29,7 +29,7 @@ MicroBit uBit;
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     // Enable per pixel rendering, with 256 level of brightness per pixel.

--- a/source/examples/hello-world/main.cpp
+++ b/source/examples/hello-world/main.cpp
@@ -29,7 +29,7 @@ MicroBit uBit;
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     // Insert your code here!

--- a/source/examples/invaders/main.cpp
+++ b/source/examples/invaders/main.cpp
@@ -279,7 +279,7 @@ spaceInvaders()
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     // Welcome message

--- a/source/examples/logic-gates/main.cpp
+++ b/source/examples/logic-gates/main.cpp
@@ -106,7 +106,7 @@ void onShake(MicroBitEvent)
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     // Register to receive events when the micro:bit is shaken.

--- a/source/examples/proximity-heart/main.cpp
+++ b/source/examples/proximity-heart/main.cpp
@@ -131,7 +131,7 @@ void onData(MicroBitEvent)
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     // Setup some button handlers to allow direct heartbeat control with buttons

--- a/source/examples/simple-animation/main.cpp
+++ b/source/examples/simple-animation/main.cpp
@@ -29,7 +29,7 @@ MicroBit uBit;
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     // Setup a simple triangular waveform.

--- a/source/examples/simple-radio-rx/main.cpp
+++ b/source/examples/simple-radio-rx/main.cpp
@@ -40,7 +40,7 @@ void onData(MicroBitEvent)
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     uBit.messageBus.listen(MICROBIT_ID_RADIO, MICROBIT_RADIO_EVT_DATAGRAM, onData);

--- a/source/examples/simple-radio-tx/main.cpp
+++ b/source/examples/simple-radio-tx/main.cpp
@@ -29,7 +29,7 @@ MicroBit    uBit;
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
     uBit.radio.enable();
 

--- a/source/examples/snake/main.cpp
+++ b/source/examples/snake/main.cpp
@@ -190,7 +190,7 @@ void snake()
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     // Insert your code here!

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -29,7 +29,7 @@ MicroBit uBit;
 
 int main()
 {
-    // Initialise the micro:bit runtime.
+    // Initialize the micro:bit runtime.
     uBit.init();
 
     // Insert your code here!


### PR DESCRIPTION
I found that all the "initialize"s in comments of example programs were miss-spelled. This PR fixes all of them.